### PR TITLE
using NGROK_SUBDOMAIN for /slack/add

### DIFF
--- a/server/handlers/slack.js
+++ b/server/handlers/slack.js
@@ -33,7 +33,7 @@ module.exports = {
     },
     handler: (request, reply) => {
       console.log(`[WALKIE][${request.method}][${request.url.path}]`);
-      doOauthRequest('https://walkiebot.ngrok.io/slack/add', request.query.code)
+      doOauthRequest('https://${process.env.NGROK_SUBDOMAIN}/slack/add', request.query.code)
         .then(data => {
           if (!data.ok) throw new Error(data.error);
 


### PR DESCRIPTION
Related to Issue #1 

@freeall ~I'm not actually sure if this addresses the Slack login properly or whether it should be APP_HOST instead.~  This is correct.

Unfortunately after I Authorize on Slack, I'm getting 
```
Debug: internal, implementation, error 
    Error: error:0906D06C:PEM routines:PEM_read_bio:no start line
    at Sign.sign (crypto.js:285:26)
    at Object.sign (/Users/agranov/work/walkiebot/node_modules/jwa/index.js:76:45)
    at jwsSign (/Users/agranov/work/walkiebot/node_modules/jws/lib/sign-stream.js:32:24)
    at SignStream.sign (/Users/agranov/work/walkiebot/node_modules/jws/lib/sign-stream.js:58:21)
    at SignStream.<anonymous> (/Users/agranov/work/walkiebot/node_modules/jws/lib/sign-stream.js:46:12)
    at Object.onceWrapper (events.js:293:19)
    at emitNone (events.js:86:13)
    at DataStream.emit (events.js:188:7)
    at DataStream.<anonymous> (/Users/agranov/work/walkiebot/node_modules/jws/lib/data-stream.js:32:12)
    at _combinedTickCallback (internal/process/next_tick.js:73:7)
```
no matter how I store the JWT tokens in `local.json`

How are you expecting the JWT file contents as JSON there?