### PR TITLE
Allow user with empty slack oauth permission scope

### DIFF
--- a/server/handlers/slack.js
+++ b/server/handlers/slack.js
@@ -95,7 +95,7 @@ module.exports = {
             data.user,
             {
               access_token: data.access_token,
-              scope: data.scope ? data.scope.split(',') : '',
+              scope: data.scope ? data.scope.split(',') : [],
               lastLogin: new Date()
             }
           );

--- a/server/handlers/slack.js
+++ b/server/handlers/slack.js
@@ -95,7 +95,7 @@ module.exports = {
             data.user,
             {
               access_token: data.access_token,
-              scope: data.scope.split(','),
+              scope: data.scope ? data.scope.split(',') : '',
               lastLogin: new Date()
             }
           );


### PR DESCRIPTION
### Problem
Using slack's [workspace api](https://api.slack.com/workspace-apps-preview) that's still in preview, I was getting an error because it has an empty scope object during the handshake. 

### Solution (this PR)
Allow empty user scopes by checking if the returned json object's scope attribute exists.