### PR TITLE
Hotfix/don't parse cookies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # source: https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
-FROM node:carbon
+FROM node:10-buster
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,20 +4,14 @@ FROM node:10-buster
 # Create app directory
 WORKDIR /usr/src/app
 
-# Install app dependencies
-# A wildcard is used to ensure both package.json AND package-lock.json are copied
-# where available (npm@5+)
-COPY package.json ./
-COPY yarn.lock ./
-
-RUN yarn --ignore-scripts && npm rebuild node-sass --force
-# If you are building your code for production
-# RUN npm install --only=production
-
 # Bundle app source
 COPY . .
 
-RUN yarn build-prod
+RUN yarn --ignore-scripts \
+  && npm rebuild node-sass --force \
+  && npm install --only=production \
+  && yarn build-prod
 
-EXPOSE 8080
+EXPOSE 8000
+
 CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 ---
 version: '3.3'
+
 services:
   web:
     build: .
@@ -15,3 +16,10 @@ services:
     image: mongo:3.6
     ports:
       - 27017:27017
+    volumes:
+      - "mongo_config:/data/configdb"
+      - "mongo_data:/data/db"
+
+volumes:
+  mongo_config:
+  mongo_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@ services:
     depends_on:
       - mongodb
   mongodb:
-    image: mongo:3.2
+    image: mongo:3.6
     ports:
       - 27017:27017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     depends_on:
       - mongodb
   mongodb:
-    image: mongo:3.6
+    image: mongo:4.0
     ports:
       - 27017:27017
     volumes:

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,17 @@ require('load-environment');
 
 const Hapi = require('hapi');
 
-const server = new Hapi.Server();
+const server = new Hapi.Server({
+  connections: {
+    routes: {
+      state: {
+        parse: false,
+        failAction: 'ignore'
+      }
+    }
+  }
+});
+
 const accessControl = require('./modules/access-control');
 
 const JWT_PUBLIC = process.env.JWT_PUBLIC && process.env.JWT_PUBLIC.replace(/\\n/g, '\n');


### PR DESCRIPTION
Fixes an issue with unparsable `Slido.Privacy` cookie causing
```
{
  "statusCode": 400,
  "error": "Bad Request",
  "message": "Invalid cookie value"
}
```